### PR TITLE
Fix toLongLong overflow and improve division multiples

### DIFF
--- a/OmniInt.h
+++ b/OmniInt.h
@@ -435,9 +435,11 @@ bool OmniInt::operator!=(const OmniInt &other) const { return compare(other) != 
 // --- 其他成员函数 ---
 long long OmniInt::toLongLong() const
 {
+    static const OmniInt llong_max(std::numeric_limits<long long>::max());
+    static const OmniInt llong_min(std::numeric_limits<long long>::min());
+
     if (pos)
     {
-        static const OmniInt llong_max(std::numeric_limits<long long>::max());
         if (*this > llong_max)
         {
             throw std::overflow_error("OmniInt value too large for long long");
@@ -445,19 +447,30 @@ long long OmniInt::toLongLong() const
     }
     else
     {
-        static const OmniInt llong_min(std::numeric_limits<long long>::min());
         if (*this < llong_min)
         {
             throw std::overflow_error("OmniInt value too small for long long");
         }
     }
 
-    long long result = 0;
+    unsigned long long magnitude = 0;
     for (int i = val.size() - 1; i >= 0; --i)
     {
-        result = result * 10 + val[i];
+        magnitude = magnitude * 10 + static_cast<unsigned long long>(val[i]);
     }
-    return pos ? result : -result;
+
+    if (pos)
+    {
+        return static_cast<long long>(magnitude);
+    }
+
+    const unsigned long long min_magnitude =
+        static_cast<unsigned long long>(std::numeric_limits<long long>::max()) + 1ULL;
+    if (magnitude == min_magnitude)
+    {
+        return std::numeric_limits<long long>::min();
+    }
+    return -static_cast<long long>(magnitude);
 }
 
 std::string OmniInt::toString() const
@@ -518,7 +531,7 @@ std::pair<OmniInt, OmniInt> OmniInt::divide_and_remainder(const OmniInt &divisor
     std::vector<OmniInt> multiples(10);
     for (int i = 1; i <= 9; ++i)
     {
-        multiples[i] = abs_divisor * i;
+        multiples[i] = multiples[i - 1] + abs_divisor;
     }
 
     std::vector<int> quotient_digits;

--- a/test_omniint.cpp
+++ b/test_omniint.cpp
@@ -268,6 +268,23 @@ void test_utility_and_streams()
     test_case("Stream I/O (<< and >>)", a == b);
 }
 
+void test_toLongLong_limits()
+{
+    std::cout << "\n--- Testing toLongLong() Limits ---\n";
+
+    OmniInt max_val(std::numeric_limits<long long>::max());
+    test_case("toLongLong() at LLONG_MAX",
+              max_val.toLongLong() == std::numeric_limits<long long>::max());
+
+    OmniInt min_val(std::numeric_limits<long long>::min());
+    test_case("toLongLong() at LLONG_MIN",
+              min_val.toLongLong() == std::numeric_limits<long long>::min());
+
+    OmniInt mid_neg("-123456789012345678");
+    test_case("toLongLong() negative mid-range",
+              mid_neg.toLongLong() == -123456789012345678LL);
+}
+
 void test_sqrt()
 {
     std::cout << "\n--- Testing sqrt() Function ---\n";
@@ -349,6 +366,7 @@ int main()
     test_arithmetic_operators();
     test_compound_and_increment();
     test_utility_and_streams();
+    test_toLongLong_limits();
     test_sqrt();
     test_gcd(); // <-- 新增对 gcd 测试的调用
     test_exceptions();


### PR DESCRIPTION
## Summary
- avoid signed overflow in OmniInt::toLongLong by accumulating with unsigned magnitude and handling LLONG_MIN explicitly
- build long-division multiples incrementally to remove repeated OmniInt multiplications
- add regression tests that cover toLongLong conversions at signed 64-bit limits and a representative negative value

## Testing
- g++ -std=c++17 -O2 test_omniint.cpp -o test_omniint
- ./test_omniint

------
https://chatgpt.com/codex/tasks/task_e_68f02c1623b083338c70f0b754122677